### PR TITLE
Resolve weird issues looking up addresses by switching interfaceIndex to the proper type

### DIFF
--- a/Bonjour/MYAddressLookup.h
+++ b/Bonjour/MYAddressLookup.h
@@ -26,7 +26,7 @@
 
 /** The index of the network interface to use, or zero (the default) for any interface.
     You usually don't need to set this. */
-@property UInt16 interfaceIndex;
+@property uint32_t interfaceIndex;
 
 /** The resulting address(es) of the host, as HostAddress objects. */
 @property (readonly) NSSet *addresses;

--- a/Bonjour/MYAddressLookup.m
+++ b/Bonjour/MYAddressLookup.m
@@ -24,7 +24,7 @@
 {
     MYBonjourService *_service;
     NSString *_hostname;
-    UInt16 _interfaceIndex;
+    uint32_t _interfaceIndex;
     NSMutableSet *_addresses;
     UInt16 _port;
     CFAbsoluteTime _expires;


### PR DESCRIPTION
Resolve weird issues looking up addresses by switching interfaceIndex to the proper type.

I'm not sure why this was suddenly causing issues in my app, it used to work - maybe an OS update or something, but interfaceIndex was coming in as -1, which got changed to what I'm assuming was no longer a sentinal value when the type got squashed.
