### PR TITLE
Fixed https://github.com/snej/MYNetwork/issues/9

### DIFF
--- a/TCP/TCPConnection.m
+++ b/TCP/TCPConnection.m
@@ -54,7 +54,7 @@ NSString* const TCPErrorDomain = @"TCP";
 }
 
 
-static NSMutableArray *sAllConnections;
+static NSMutableArray *sAllConnections = NULL;
 
 
 - (Class) readerClass   {return [TCPReader class];}
@@ -65,6 +65,12 @@ static NSMutableArray *sAllConnections;
             inputStream: (NSInputStream*)input
            outputStream: (NSOutputStream*)output
 {
+    static dispatch_once_t predicate;
+	dispatch_once(&predicate, ^{
+		sAllConnections = [[NSMutableArray alloc] init];
+	});
+
+    
     self = [super init];
     if (self != nil) {
         if( !input || !output ) {


### PR DESCRIPTION
- ARC is more aggressive than retain/release/autorelease used to be, and it is causing occasional issues on disconnect
- It appears that TCPConnection's "sAllConnections" static mutable array variable, which would solve this, is never (and has never actually been) initialized to an real NSMutableArray object.
- Adding that initialization appears to fix the issue.
