### PR TITLE
Fixed a crash caused by unintuitive objc_msgSend behavior on arm64

### DIFF
--- a/TCP/TCPEndpoint.m
+++ b/TCP/TCPEndpoint.m
@@ -57,7 +57,8 @@ NSString* const kTCPPropertySSLClientSideAuthentication = @"kTCPPropertySSLClien
 {
     if( [_delegate respondsToSelector: selector] ) {
         @try{
-            objc_msgSend(_delegate, selector, self, param);
+            void (*action)(id, SEL, id, id) = (void (*)(id, SEL, id, id)) objc_msgSend;
+            action(_delegate, selector, self, param);
             //formerly [_delegate performSelector: selector withObject: self withObject: param];
             // but the compiler doesn't like that with ARC
         }catchAndReport(@"%@ delegate",self.class);


### PR DESCRIPTION
For more info, check out "Dispatch Objective-C Messages Using the Method Function's Prototype" here:
https://developer.apple.com/library/ios/documentation/General/Conceptual/CocoaTouch64BitGuide/ConvertingYourAppto64-Bit/ConvertingYourAppto64-Bit.html
